### PR TITLE
Disable buttons when Login and Signup forms are invalid

### DIFF
--- a/src/app/my-account/my-account.component.ts
+++ b/src/app/my-account/my-account.component.ts
@@ -11,6 +11,7 @@ import {UserDetailsService} from "../shared/services/user-details/user-details.s
 export class MyAccountComponent implements OnInit {
 
   user?:User;
+  errorMessage?:string;
 
   constructor(
     private authService: AuthService,
@@ -24,15 +25,7 @@ export class MyAccountComponent implements OnInit {
   getLoggedInUserDetails(): void {
     this.userDetailsService.getLoggedInUserDetails()
       .subscribe({
-        next: res => {
-          this.user = res.user;
-          },
-        complete: () => {
-          console.log('Fetched user details');
-        },
-        error: err => {
-          console.log(err);
-        }
+        next: user => this.user = user
       });
   }
 

--- a/src/app/navbar/navbar.component.html
+++ b/src/app/navbar/navbar.component.html
@@ -48,8 +48,10 @@
               class="dropdown-menu z-50 my-4 text-base list-none bg-white rounded divide-y divide-gray-100 shadow"
               [ngClass]="showDropdownPopover ? 'block' : 'hidden'">
               <div class="py-3 px-4">
-                <span class="block text-sm text-gray-900">{{getUsername()}}</span>
-                <span class="block text-sm font-medium text-gray-500 truncate">{{getEmail()}}</span>
+                <ng-container *ngIf="(user$ | async) as userDetails">
+                  <span class="block text-sm text-gray-900">{{ userDetails.username }}</span>
+                  <span class="block text-sm font-medium text-gray-500 truncate">{{ userDetails.email }}</span>
+                </ng-container>
               </div>
               <ul class="py-1" aria-labelledby="dropdown">
                 <li>

--- a/src/app/navbar/navbar.component.ts
+++ b/src/app/navbar/navbar.component.ts
@@ -4,6 +4,7 @@ import {createPopper} from "@popperjs/core";
 import {Router} from "@angular/router";
 import {User} from "../shared/models/User";
 import {UserDetailsService} from "../shared/services/user-details/user-details.service";
+import {Observable} from "rxjs";
 
 @Component({
   selector: 'app-navbar',
@@ -13,7 +14,7 @@ import {UserDetailsService} from "../shared/services/user-details/user-details.s
 export class NavbarComponent implements OnInit, AfterViewInit {
   public showDropdownPopover:boolean = false;
 
-  user?: User;
+  user$?:Observable<User>;
 
   @ViewChild("btnDropdownRef", { static: false })
   btnDropdownRef!: ElementRef;
@@ -29,7 +30,7 @@ export class NavbarComponent implements OnInit, AfterViewInit {
   ) { }
 
   ngOnInit() {
-    this.getLoggedInUserDetails();
+    this.user$ = this.userDetailsService.getLoggedInUserDetails();
   }
 
   ngAfterViewInit() {
@@ -45,29 +46,6 @@ export class NavbarComponent implements OnInit, AfterViewInit {
   toggleDropdown(event:any) {
     event.preventDefault();
     this.showDropdownPopover = !this.showDropdownPopover;
-  }
-
-  getLoggedInUserDetails(): void {
-    this.userDetailsService.getLoggedInUserDetails()
-      .subscribe({
-        next: res => {
-          this.user = res.user;
-        },
-        complete: () => {
-          console.log('Fetched user details');
-        },
-        error: err => {
-          console.log(err);
-        }
-      });
-  }
-
-  getUsername(): string {
-    return this.user?.username ?? "No username found.";
-  }
-
-  getEmail(): string {
-    return this.user?.email ?? "No email found.";
   }
 
   isLoggedIn(): boolean {

--- a/src/app/shared/auth/components/login/login.component.html
+++ b/src/app/shared/auth/components/login/login.component.html
@@ -21,8 +21,9 @@
       <div class="mt-6">
         <button
           type="submit"
-          class="w-full px-4 py-2 tracking-wide text-white font-work-sans font-semi-bold transition-colors duration-200 transform bg-purple-700
-          rounded-md hover:bg-purple-600 focus:outline-none focus:bg-purple-600">
+          [disabled]="form.invalid"
+          class="w-full px-4 py-2 tracking-wide text-white font-work-sans font-semi-bold transition-colors duration-200
+          transform disabled:bg-purple-400 bg-purple-700 rounded-md hover:bg-purple-600 focus:outline-none focus:bg-purple-600">
           Login
         </button>
       </div>

--- a/src/app/shared/auth/components/login/login.component.ts
+++ b/src/app/shared/auth/components/login/login.component.ts
@@ -2,8 +2,6 @@ import { Component } from '@angular/core';
 import { FormControl, Validators, FormGroup } from '@angular/forms';
 import {AuthService} from "../../services/auth.service";
 import {Router} from "@angular/router";
-import {LoggingSeverity} from "../../../services/logging/loggingSeverity";
-import {LoggingService} from "../../../services/logging/logging.service";
 
 @Component({
   selector: 'app-login',
@@ -14,14 +12,13 @@ export class LoginComponent {
   public errorMessage?:string;
 
   form = new FormGroup({
-    "username": new FormControl("test", Validators.required),
-    "password": new FormControl("Qwerty1@34", Validators.required)
+    "username": new FormControl("", Validators.required),
+    "password": new FormControl("", Validators.required)
   });
 
   constructor(
     private authService: AuthService,
-    private router: Router,
-    private loggingService: LoggingService
+    private router: Router
   ) { }
 
   onSubmit(): void {
@@ -29,15 +26,11 @@ export class LoginComponent {
     let password:string = this.form.controls.password.value ?? "PASSWORD MISSING";
 
     this.authService.login(username, password)
-      .subscribe(
-      {
-        next: (res) => this.authService.setSession(res),
+      .subscribe({
         complete: () => {
-          this.log('User successfully signed in!', LoggingSeverity.SUCCESS);
           this.redirectToMyAccount();
         },
         error: err => {
-          this.log(`${JSON.stringify(err)}`, LoggingSeverity.ERROR);
           this.errorMessage = err.error.errorMessage;
         }
       });
@@ -45,23 +38,5 @@ export class LoginComponent {
 
   private redirectToMyAccount(): void {
     this.router.navigateByUrl("/myaccount");
-  }
-
-  private log(m:string, severity:LoggingSeverity) {
-    let message:string = `LoginService: ${m}`;
-
-    switch (severity) {
-      case LoggingSeverity.SUCCESS:
-        this.loggingService.logSuccess(message);
-        break;
-      case LoggingSeverity.ERROR:
-        this.loggingService.logError(message);
-        break;
-      case LoggingSeverity.INFO:
-        this.loggingService.logInfo(message);
-        break;
-      default:
-        this.loggingService.logInfo(message);
-    }
   }
 }

--- a/src/app/shared/auth/components/signup/signup.component.html
+++ b/src/app/shared/auth/components/signup/signup.component.html
@@ -11,7 +11,7 @@
   <div class="mt-4">
     <label for="email"
            class="block font-sanchez text-sm text-gray-800">Email</label>
-    <input type="string" id="email" formControlName="username"
+    <input type="string" id="email" formControlName="email"
            class="block w-full px-4 py-2 mt-2 text-purple-700 bg-white border rounded-md focus:border-purple-400
              focus:ring-purple-300 focus:outline-none focus:ring focus:ring-opacity-40">
   </div>
@@ -28,8 +28,9 @@
     <div class="mt-6">
       <button
         type="submit"
-        class="w-full px-4 py-2 tracking-wide text-white font-work-sans font-semi-bold transition-colors duration-200 transform bg-purple-700
-          rounded-md hover:bg-purple-600 focus:outline-none focus:bg-purple-600">
+        [disabled]="form.invalid"
+        class="w-full px-4 py-2 tracking-wide text-white font-work-sans font-semi-bold transition-colors duration-200
+        transform disabled:bg-purple-400 bg-purple-700 rounded-md hover:bg-purple-600 focus:outline-none focus:bg-purple-600">
         Sign Up
       </button>
     </div>

--- a/src/app/shared/auth/components/signup/signup.component.ts
+++ b/src/app/shared/auth/components/signup/signup.component.ts
@@ -1,8 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, Validators, FormGroup } from '@angular/forms';
 import {AuthService} from "../../services/auth.service";
-import {LoggingSeverity} from "../../../services/logging/loggingSeverity";
-import {LoggingService} from "../../../services/logging/logging.service";
+import {Router} from "@angular/router";
 
 @Component({
   selector: 'app-signup',
@@ -13,14 +12,14 @@ export class SignupComponent implements OnInit {
   public errorMessage?:string;
 
   form = new FormGroup({
-    "username": new FormControl("test", Validators.required),
-    "email": new FormControl("test@example.com", Validators.required),
-    "password": new FormControl("Qwerty1@34", Validators.required)
+    "username": new FormControl("", Validators.required),
+    "email": new FormControl("", Validators.required),
+    "password": new FormControl("", Validators.required)
   })
 
   constructor(
     private authService:AuthService,
-    private loggingService:LoggingService
+    private router: Router
   ) { }
 
   ngOnInit(): void {
@@ -34,31 +33,26 @@ export class SignupComponent implements OnInit {
     this.authService.signup(username, email, password)
       .subscribe(
         {
-          complete: () => {
-            this.log('User successfully signed up!', LoggingSeverity.SUCCESS);
-          },
+          complete: () => this.loginAfterSuccessfulSignup(username, password),
           error: err => {
-            this.log(`${JSON.stringify(err)}`, LoggingSeverity.ERROR);
             this.errorMessage = err.error.errorMessage;
           }
         });
   }
 
-  private log(m:string, severity:LoggingSeverity) {
-    let message:string = `SignupService: ${m}`;
+  private loginAfterSuccessfulSignup(username:string, password:string): void {
+    this.authService.login(username, password)
+      .subscribe({
+        complete: () => {
+          this.redirectToMyAccount();
+        },
+        error: err => {
+          this.errorMessage = err.error.errorMessage;
+        }
+      });
+  }
 
-    switch (severity) {
-      case LoggingSeverity.SUCCESS:
-        this.loggingService.logSuccess(message);
-        break;
-      case LoggingSeverity.ERROR:
-        this.loggingService.logError(message);
-        break;
-      case LoggingSeverity.INFO:
-        this.loggingService.logInfo(message);
-        break;
-      default:
-        this.loggingService.logInfo(message);
-    }
+  private redirectToMyAccount(): void {
+    this.router.navigateByUrl("/myaccount");
   }
 }

--- a/src/app/shared/services/logging/logging.service.ts
+++ b/src/app/shared/services/logging/logging.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import {LoggingSeverity} from "./loggingSeverity";
 
 @Injectable({
   providedIn: 'root'
@@ -7,15 +8,32 @@ export class LoggingService {
 
   constructor() { }
 
-  public logInfo(message:string): void {
+  public log(message:string, severity?:LoggingSeverity) {
+
+    switch (severity) {
+      case LoggingSeverity.SUCCESS:
+        this.logSuccess(message);
+        break;
+      case LoggingSeverity.ERROR:
+        this.logError(message);
+        break;
+      case LoggingSeverity.INFO:
+        this.logInfo(message);
+        break;
+      default:
+        this.logInfo(message);
+    }
+  }
+
+  private logInfo(message:string): void {
     console.log(`[INFO] ${message}`);
   }
 
-  public logError(message:string): void {
+  private logError(message:string): void {
     console.log(`[ERROR] ${message}`);
   }
 
-  public logSuccess(message:string): void {
+  private logSuccess(message:string): void {
     console.log(`[SUCCESS] ${message}`);
   }
 }

--- a/src/app/shared/services/user-details/user-details.service.ts
+++ b/src/app/shared/services/user-details/user-details.service.ts
@@ -1,8 +1,11 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 import {environment} from "../../../../environments/environment";
 import {HttpClient} from "@angular/common/http";
-import {Observable} from "rxjs";
+import {map, Observable, shareReplay, tap} from "rxjs";
 import {GetUserDetailsDto} from "./dtos/GetUserDetailsDto";
+import {LoggingService} from "../logging/logging.service";
+import {LoggingSeverity} from "../logging/loggingSeverity";
+import {User} from "../../models/User";
 
 @Injectable({
   providedIn: 'root'
@@ -11,12 +14,21 @@ export class UserDetailsService {
   private readonly GETLOGGEDINUSERDETAILS_ENDPOINT:string = `${environment.apiUrl}/users/detail`;
 
   constructor(
-    private http: HttpClient
+    private http: HttpClient,
+    private loggingService: LoggingService
   ) { }
 
-  getLoggedInUserDetails(): Observable<GetUserDetailsDto> {
-    return this.http.get<GetUserDetailsDto>(
-      this.GETLOGGEDINUSERDETAILS_ENDPOINT
-    );
+  getLoggedInUserDetails(): Observable<User> {
+    let SUCCESS_MESSAGE:string = "Fetched user's details!";
+
+    return this.http.get<GetUserDetailsDto>(this.GETLOGGEDINUSERDETAILS_ENDPOINT)
+      .pipe(
+        map((res) => res.user),
+        tap({
+          complete: () => this.loggingService.log(SUCCESS_MESSAGE, LoggingSeverity.SUCCESS),
+          error: err => this.loggingService.log(err.error.errorMessage)
+        }),
+        shareReplay()
+      );
   }
 }


### PR DESCRIPTION
This pull-request:
- adds the following:
   - Buttons are disabled when any field is empty in the Login and Signup pages
- changes the following:
   - After signing up, a user is now automatically logged in. 
   - The logging service is refactored to reduce code-duplication.

