### PR TITLE
Add implementation for Adopt Book button

### DIFF
--- a/src/app/add-book/dtos/AddBookDto.ts
+++ b/src/app/add-book/dtos/AddBookDto.ts
@@ -1,7 +1,7 @@
 import {Book} from "../../shared/models/Book";
 import {Nullable} from "../../shared/types/Nullable";
 
-export type AddBookDto = Nullable<Omit<Book, ("id" | "listedByUser")>>;
+export type AddBookDto = Nullable<Omit<Book, ("id" | "listedByUser" | "adoptedByUser")>>;
 
 export const DEFAULT_ADD_BOOK_DTO:AddBookDto = {
   title: "",

--- a/src/app/library/components/book-details/book-details.component.html
+++ b/src/app/library/components/book-details/book-details.component.html
@@ -24,14 +24,14 @@
             <div class="flex items-center space-x-3">
               <h3 class="text-sm title-font text-gray-500 tracking-widest">Listed by:</h3>
               <span class="bg-purple-100 text-purple-800 text-sm font-medium mr-2 px-2.5 py-0.5 rounded dark:bg-purple-200 dark:text-purple-900">
-            {{ bookDetails.listedByUser.username }}
+                {{ bookDetails.listedByUser.username }}
               </span>
             </div>
 
             <div>
-              <button type="button"
-                      class="text-white bg-blue-700 hover:bg-blue-800 font-medium
-              rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">
+              <button type="button" [disabled]="bookDetails.adoptedByUser !== null" (click)="adoptBook()"
+                      class="text-white bg-blue-700 disabled:bg-blue-300 hover:bg-blue-800 font-medium
+                      rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">
                 Adopt
               </button>
             </div>

--- a/src/app/library/components/book-details/book-details.component.ts
+++ b/src/app/library/components/book-details/book-details.component.ts
@@ -21,6 +21,15 @@ export class BookDetailsComponent implements OnInit {
     this.book = this.getBook();
   }
 
+  public adoptBook(): void {
+    this.book.pipe(
+      switchMap(bookDetails => this.libraryService.adoptBook(bookDetails.id))
+    ).subscribe({
+      // reload the page when book has been successfully adopted
+      complete: () => location.reload()
+    });
+  }
+
   private getBook(): Observable<Book> {
     return this.getIdFromRoute()
       .pipe(

--- a/src/app/library/components/book-list-item/book-list-item.component.html
+++ b/src/app/library/components/book-list-item/book-list-item.component.html
@@ -1,6 +1,6 @@
 <section class="text-gray-700 body-font overflow-hidden bg-white">
   <div class="mx-auto flex flex-wrap">
-    <button class="w-full" (click)="onClick()">
+    <button class="w-full" (click)="navigateToDetailsPage()">
       <img alt="ecommerce" class="w-full object-cover object-center rounded border border-gray-200" src="https://www.whitmorerarebooks.com/pictures/medium/2465.jpg">
     </button>
 
@@ -17,8 +17,8 @@
       </div>
 
       <div>
-        <button type="button"
-                class="text-white bg-blue-700 hover:bg-blue-800 font-medium
+        <button type="button" [disabled]="book.adoptedByUser !== null" (click)="adoptBook()"
+                class="text-white bg-blue-700 disabled:bg-blue-300 hover:bg-blue-800 font-medium
                 rounded-lg text-sm px-5 py-2.5 mr-2 mb-2 focus:outline-none">
           Adopt
         </button>

--- a/src/app/library/components/book-list-item/book-list-item.component.ts
+++ b/src/app/library/components/book-list-item/book-list-item.component.ts
@@ -1,6 +1,7 @@
 import {Component, Input, OnInit} from '@angular/core';
 import {Book, EMPTY_BOOK} from "../../../shared/models/Book";
 import {Router} from "@angular/router";
+import {LibraryService} from "../../services/library.service";
 
 @Component({
   selector: 'app-book-list-item',
@@ -14,14 +15,22 @@ export class BookListItemComponent implements OnInit {
   private readonly BOOK_DETAILS_ROUTE = "/book/";
 
   constructor(
+    private libraryService: LibraryService,
     private router: Router
   ) { }
 
   ngOnInit(): void {
   }
 
-  onClick(): void {
+  navigateToDetailsPage(): void {
     this.router.navigate([this.BOOK_DETAILS_ROUTE, this.book.id]);
   }
 
+  adoptBook(): void {
+    this.libraryService.adoptBook(this.book.id)
+      .subscribe({
+        // reload the page when book has been successfully adopted
+        complete: () => location.reload()
+      });
+  }
 }

--- a/src/app/library/services/library.service.ts
+++ b/src/app/library/services/library.service.ts
@@ -15,6 +15,7 @@ import {LoggingSeverity} from "../../shared/services/logging/loggingSeverity";
 export class LibraryService {
   private readonly GET_ALL_BOOKS_ENDPOINT:string = `${environment.apiUrl}/books/all`;
   private readonly GET_BOOK_ENDPOINT:string = `${environment.apiUrl}/books/book`;
+  private readonly ADOPT_BOOK_ENDPOINT:string = `${environment.apiUrl}/books/adopt`;
 
   private readonly HTTP_OPTIONS = {
     headers: new HttpHeaders({
@@ -66,6 +67,22 @@ export class LibraryService {
           error: () => this.loggingService.log(ERROR_MESSAGE, LoggingSeverity.ERROR)
         }),
         map(res => { return res.book; }),
+        shareReplay()
+      );
+  }
+
+  public adoptBook(id:number): Observable<any> {
+    let SUCCESS_MESSAGE:string = `Successfully adopted book`;
+    let ERROR_MESSAGE:string = `Failed to adopt book`;
+
+    let params:any = { id };
+
+    return this.http.get(this.ADOPT_BOOK_ENDPOINT, { params })
+      .pipe(
+        tap({
+          complete: () => this.loggingService.log(SUCCESS_MESSAGE, LoggingSeverity.SUCCESS),
+          error: () => this.loggingService.log(ERROR_MESSAGE, LoggingSeverity.ERROR)
+        }),
         shareReplay()
       );
   }

--- a/src/app/shared/models/Book.ts
+++ b/src/app/shared/models/Book.ts
@@ -6,7 +6,8 @@ export interface Book {
   author:string,
   publisher:string,
   details:string,
-  listedByUser: User
+  listedByUser: User,
+  adoptedByUser: User
 }
 
 export const EMPTY_BOOK:Book = {
@@ -15,5 +16,6 @@ export const EMPTY_BOOK:Book = {
   author: "-",
   publisher: "-",
   details: "-",
-  listedByUser: EMPTY_USER
+  listedByUser: EMPTY_USER,
+  adoptedByUser: EMPTY_USER
 }


### PR DESCRIPTION
This pull-request adds the following:
- when a user clicks "Adopt" on an available book listing, the book listing record will be updated on the backend
- when a book listing has already been adopted, the "Adopt" button will be disabled