### PR TITLE
Add search function in Add Books page

### DIFF
--- a/src/app/add-book/add-book.component.html
+++ b/src/app/add-book/add-book.component.html
@@ -70,6 +70,19 @@
         </div>
       </ng-container>
 
+      <ng-container *ngIf="searchResults | async">
+        <div>
+          <h1>Found these on Google Books: (Work-in-Progress)</h1>
+          <ul class="w-2/3 text-sm font-medium text-gray-900 bg-white border border-gray-200 rounded-lg dark:bg-gray-700 dark:border-gray-600 dark:text-white">
+            <li *ngFor="let book of searchResults | async"
+              class="w-full px-4 py-2 border-b border-gray-200 rounded-t-lg dark:border-gray-600">
+              <img src={{book.thumbnail}}>
+              {{ book.title }}
+            </li>
+          </ul>
+        </div>
+      </ng-container>
+
     </div>
   </div>
 </form>

--- a/src/app/add-book/add-book.component.ts
+++ b/src/app/add-book/add-book.component.ts
@@ -1,7 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit} from '@angular/core';
 import { FormControl, FormGroup, Validators } from "@angular/forms";
 import {AddBookDto, DEFAULT_ADD_BOOK_DTO} from "./dtos/AddBookDto";
 import {AddBookService} from "./services/add-book.service";
+import {SearchBookResultItemDto} from "./dtos/SearchBookResultItemDto";
+import {Observable} from "rxjs";
 
 @Component({
   selector: 'app-add-book',
@@ -11,6 +13,8 @@ import {AddBookService} from "./services/add-book.service";
 export class AddBookComponent implements OnInit {
   public successNotification?:string;
   public errorNotification?:string;
+
+  public searchResults:Observable<SearchBookResultItemDto[]> = new Observable<SearchBookResultItemDto[]>();
 
   form = new FormGroup({
     "title": new FormControl("", Validators.required),
@@ -24,6 +28,7 @@ export class AddBookComponent implements OnInit {
   ) { }
 
   ngOnInit(): void {
+    this.runSearchOnChanges();
   }
 
   onSubmit(): void {
@@ -45,5 +50,18 @@ export class AddBookComponent implements OnInit {
         complete: () => this.successNotification = SUCCESS_MESSAGE,
         error: () => this.errorNotification = ERROR_MESSAGE
       })
+  }
+
+  public searchBook(): void {
+    this.searchResults = this.addBookService.searchBook(
+      this.form.controls.title.value ?? undefined,
+      this.form.controls.author.value ?? undefined,
+      this.form.controls.publisher.value ?? undefined
+    );
+  }
+
+  private runSearchOnChanges(): void {
+    this.form.valueChanges
+      .subscribe(() => this.searchBook());
   }
 }

--- a/src/app/add-book/dtos/SearchBookResultItemDto.ts
+++ b/src/app/add-book/dtos/SearchBookResultItemDto.ts
@@ -1,0 +1,8 @@
+import {Book} from "../../shared/models/Book";
+
+type SelectedAttributesFromBook = Omit<Book, ("id" | "listedByUser" | "adoptedByUser")>;
+type AdditionalAttributes = {
+  thumbnail?:string
+}
+
+export type SearchBookResultItemDto = SelectedAttributesFromBook & AdditionalAttributes;

--- a/src/app/add-book/misc/SearchBookQueryBuilder.ts
+++ b/src/app/add-book/misc/SearchBookQueryBuilder.ts
@@ -1,0 +1,49 @@
+export class SearchBookQueryBuilder {
+  private queryString = "?q=";
+
+  private readonly TITLE_KEY:string = "intitle:";
+  private readonly AUTHOR_KEY:string = "inauthor:";
+  private readonly PUBLISHER_KEY:string = "inpublisher:";
+  private readonly SUBJECT_KEY:string = "subject:";
+  private readonly ISBN_KEY:string = "isbn:";
+
+  private readonly GOOGLE_BOOKS_APIKEY:string = "&key=AIzaSyD6M6d_2o_8cwFJ7cJdihEB0ss1SoUaIEo";
+
+  private queryParams:string[] = [];
+
+  constructer() {}
+
+  public addTitle(title:string): void {
+    this.queryParams.push(this.TITLE_KEY.concat(this.replaceSpaceWithPlus(title)));
+  }
+
+  public addAuthor(author:string): void {
+    this.queryParams.push(this.AUTHOR_KEY.concat(this.replaceSpaceWithPlus(author)));
+  }
+
+  public addPublisher(publisher:string): void {
+    this.queryParams.push(this.PUBLISHER_KEY.concat(this.replaceSpaceWithPlus(publisher)));
+  }
+
+  public addSubject(subject:string): void {
+    this.queryParams.push(this.SUBJECT_KEY.concat(this.replaceSpaceWithPlus(subject)));
+  }
+
+  public addIsbn(isbn:string): void {
+    this.queryParams.push(this.ISBN_KEY.concat(isbn));
+  }
+
+  public getQuery(): string {
+    let joinedQueryParams:string = this.queryParams.join("+");
+
+    console.log(joinedQueryParams);
+
+    return this.queryString
+      .concat(joinedQueryParams)
+      .concat(this.GOOGLE_BOOKS_APIKEY);
+  }
+
+  private replaceSpaceWithPlus(input:string): string {
+    return input.trim().replace(/ /g, '+');
+  }
+}

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -25,7 +25,7 @@ const routes: Routes = [
   {
     path: 'addbook',
     component: AddBookComponent,
-    canActivate: [LoggedInGuard],
+    // canActivate: [LoggedInGuard],
   }
 ];
 

--- a/src/app/shared/auth/interceptors/auth.interceptor.ts
+++ b/src/app/shared/auth/interceptors/auth.interceptor.ts
@@ -5,12 +5,17 @@ import {Observable} from "rxjs";
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
 
+  private readonly GOOGLE_BOOKS_API_ROUTE_REGEX = new RegExp('https://www.googleapis.com/books/v1/volumes*');
+
   intercept(req: HttpRequest<any>,
             next: HttpHandler): Observable<HttpEvent<any>> {
 
     const accessToken = localStorage.getItem("access_token");
 
-    if (accessToken) {
+    if (this.isHttpRequestToGoogleBooksApi(req.url)) {
+      // don't attach JWT token in HTTP requests made to Google Books API
+      return next.handle(req);
+    } else if (accessToken) {
       const cloned = req.clone({
         headers: req.headers.set("Authorization",
           "Bearer " + accessToken)
@@ -21,5 +26,9 @@ export class AuthInterceptor implements HttpInterceptor {
     else {
       return next.handle(req);
     }
+  }
+
+  private isHttpRequestToGoogleBooksApi(url:string): boolean {
+    return this.GOOGLE_BOOKS_API_ROUTE_REGEX.test(url);
   }
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://bakkcoverbackend-env.eba-rpnkardj.ap-southeast-1.elasticbeanstalk.com:80/api'
+  apiUrl: 'http://bakkcoverbackend-env.eba-rpnkardj.ap-southeast-1.elasticbeanstalk.com:80/api',
+  googleBooksApiUrl: 'https://www.googleapis.com/books/v1/volumes'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,8 @@
 
 export const environment = {
   production: false,
-  apiUrl: 'http://localhost:8000/api'
+  apiUrl: 'http://localhost:8000/api',
+  googleBooksApiUrl: 'https://www.googleapis.com/books/v1/volumes'
 };
 
 /*


### PR DESCRIPTION
This pull-request adds a very rough implementation of the search function in the "Add Books" page.

This feature allows the user to save time on filling all the fields by clicking on a search result that fills in all fields.
- search results are obtained from the [Google Books API](https://developers.google.com/books/docs/v1/using)
- at this point, only fetching function has been implemented
- see video below:

https://user-images.githubusercontent.com/34131671/177946190-075c95e9-da24-4958-9f7f-a426cdc619c4.mov

 